### PR TITLE
Add simple auth demo

### DIFF
--- a/qwer/README.md
+++ b/qwer/README.md
@@ -1,0 +1,5 @@
+# Qwer Auth Demo
+
+Simple demo landing with login and registration forms using localStorage. Register to create a user, then log in to reach the personal cabinet and log out.
+
+Open `index.html` in a browser to try it out.

--- a/qwer/cabinet.html
+++ b/qwer/cabinet.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Cabinet</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <h1>Personal Cabinet</h1>
+  <p id="welcome"></p>
+  <button id="logoutBtn">Logout</button>
+  <script src="script.js"></script>
+  <script>
+    const user = getLoggedInUser();
+    if (!user) {
+      window.location.href = 'login.html';
+    } else {
+      document.getElementById('welcome').textContent = `Welcome, ${user}!`;
+    }
+    document.getElementById('logoutBtn').addEventListener('click', () => {
+      logout();
+      window.location.href = 'index.html';
+    });
+  </script>
+</body>
+</html>

--- a/qwer/index.html
+++ b/qwer/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Landing</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <h1>Welcome</h1>
+  <button onclick="location.href='login.html'">Login</button>
+  <button onclick="location.href='register.html'">Register</button>
+</body>
+</html>

--- a/qwer/login.html
+++ b/qwer/login.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Login</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <h1>Login</h1>
+  <form id="loginForm">
+    <input id="loginUsername" placeholder="Username" required>
+    <input id="loginPassword" type="password" placeholder="Password" required>
+    <button type="submit">Login</button>
+  </form>
+  <div id="loginMessage"></div>
+  <script src="script.js"></script>
+  <script>
+    document.getElementById('loginForm').addEventListener('submit', function(e) {
+      e.preventDefault();
+      const username = document.getElementById('loginUsername').value;
+      const password = document.getElementById('loginPassword').value;
+      if (authenticate(username, password)) {
+        window.location.href = 'cabinet.html';
+      } else {
+        document.getElementById('loginMessage').textContent = 'Invalid credentials';
+      }
+    });
+  </script>
+</body>
+</html>

--- a/qwer/register.html
+++ b/qwer/register.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Register</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <h1>Register</h1>
+  <form id="registerForm">
+    <input id="registerUsername" placeholder="Username" required>
+    <input id="registerPassword" type="password" placeholder="Password" required>
+    <button type="submit">Register</button>
+  </form>
+  <div id="registerMessage"></div>
+  <script src="script.js"></script>
+  <script>
+    document.getElementById('registerForm').addEventListener('submit', function(e) {
+      e.preventDefault();
+      const username = document.getElementById('registerUsername').value;
+      const password = document.getElementById('registerPassword').value;
+      if (registerUser(username, password)) {
+        window.location.href = 'cabinet.html';
+      } else {
+        document.getElementById('registerMessage').textContent = 'User already exists';
+      }
+    });
+  </script>
+</body>
+</html>

--- a/qwer/script.js
+++ b/qwer/script.js
@@ -1,0 +1,39 @@
+function getUsers() {
+  return JSON.parse(localStorage.getItem('users') || '{}');
+}
+
+function saveUsers(users) {
+  localStorage.setItem('users', JSON.stringify(users));
+}
+
+function registerUser(username, password) {
+  const users = getUsers();
+  if (users[username]) {
+    return false;
+  }
+  users[username] = password;
+  saveUsers(users);
+  setLoggedInUser(username);
+  return true;
+}
+
+function authenticate(username, password) {
+  const users = getUsers();
+  if (users[username] === password) {
+    setLoggedInUser(username);
+    return true;
+  }
+  return false;
+}
+
+function setLoggedInUser(username) {
+  localStorage.setItem('loggedInUser', username);
+}
+
+function getLoggedInUser() {
+  return localStorage.getItem('loggedInUser');
+}
+
+function logout() {
+  localStorage.removeItem('loggedInUser');
+}

--- a/qwer/style.css
+++ b/qwer/style.css
@@ -1,0 +1,22 @@
+body {
+  font-family: Arial, sans-serif;
+  max-width: 600px;
+  margin: 2rem auto;
+  text-align: center;
+}
+
+button {
+  padding: 0.5rem 1rem;
+  margin: 0.5rem;
+}
+
+form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+input {
+  padding: 0.5rem;
+}


### PR DESCRIPTION
## Summary
- Provide landing page with login and registration links in new `qwer` project
- Implement working login/registration forms backed by `localStorage`
- Show a simple personal cabinet page with logout option
- Document usage in README

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: dependency conflict for @react-three/drei)*

------
https://chatgpt.com/codex/tasks/task_e_68a340c93cd8832e894a1825e36e4bba