### PR TITLE
Add localStorage auth demo with admin panel and OAuth hooks

### DIFF
--- a/LK/.gitignore
+++ b/LK/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+users.db

--- a/LK/README.md
+++ b/LK/README.md
@@ -1,0 +1,18 @@
+# LK Auth Demo
+
+Simple landing with registration, login and password reset backed by a SQLite database.
+
+## Setup
+
+```bash
+# install dependencies
+npm install
+
+# create database
+sqlite3 users.db < schema.sql
+
+# start server
+npm start
+```
+
+Open <http://localhost:3000/index.html> in a browser to try it out.

--- a/LK/cabinet.html
+++ b/LK/cabinet.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Cabinet</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <h1>Personal Cabinet</h1>
+  <p id="welcome"></p>
+  <button id="logoutBtn">Logout</button>
+  <script src="script.js"></script>
+  <script>
+    const user = getLoggedInUser();
+    if (!user) {
+      window.location.href = 'login.html';
+    } else {
+      document.getElementById('welcome').textContent = `Welcome, ${user}!`;
+    }
+    document.getElementById('logoutBtn').addEventListener('click', () => {
+      logout();
+      window.location.href = 'index.html';
+    });
+  </script>
+</body>
+</html>

--- a/LK/index.html
+++ b/LK/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Landing</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <h1>Welcome</h1>
+  <button onclick="location.href='login.html'">Login</button>
+  <button onclick="location.href='register.html'">Register</button>
+</body>
+</html>

--- a/LK/login.html
+++ b/LK/login.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Login</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <h1>Login</h1>
+  <form id="loginForm">
+    <input id="loginUsername" placeholder="Username" required>
+    <input id="loginPassword" type="password" placeholder="Password" required>
+    <button type="submit">Login</button>
+  </form>
+  <a href="reset.html">Forgot password?</a>
+  <div id="loginMessage"></div>
+  <script src="script.js"></script>
+  <script>
+    document.getElementById('loginForm').addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const username = document.getElementById('loginUsername').value;
+      const password = document.getElementById('loginPassword').value;
+      if (await loginUser(username, password)) {
+        window.location.href = 'cabinet.html';
+      } else {
+        document.getElementById('loginMessage').textContent = 'Invalid credentials';
+      }
+    });
+  </script>
+</body>
+</html>

--- a/LK/package.json
+++ b/LK/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "lk-auth-demo",
+  "version": "1.0.0",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "bcryptjs": "^2.4.3",
+    "express": "^4.18.2",
+    "sqlite3": "^5.1.6"
+  }
+}

--- a/LK/register.html
+++ b/LK/register.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Register</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <h1>Register</h1>
+  <form id="registerForm">
+    <input id="registerUsername" placeholder="Username" required>
+    <input id="registerEmail" type="email" placeholder="Email" required>
+    <input id="registerPassword" type="password" placeholder="Password" required>
+    <button type="submit">Register</button>
+  </form>
+  <div id="registerMessage"></div>
+  <script src="script.js"></script>
+  <script>
+    document.getElementById('registerForm').addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const username = document.getElementById('registerUsername').value;
+      const email = document.getElementById('registerEmail').value;
+      const password = document.getElementById('registerPassword').value;
+      if (await registerUser(username, email, password)) {
+        window.location.href = 'cabinet.html';
+      } else {
+        document.getElementById('registerMessage').textContent = 'User already exists';
+      }
+    });
+  </script>
+</body>
+</html>

--- a/LK/reset.html
+++ b/LK/reset.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Reset Password</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <h1>Reset Password</h1>
+  <form id="resetForm">
+    <input id="resetUsername" placeholder="Username" required>
+    <input id="resetPassword" type="password" placeholder="New Password" required>
+    <button type="submit">Reset</button>
+  </form>
+  <div id="resetMessage"></div>
+  <script src="script.js"></script>
+  <script>
+    document.getElementById('resetForm').addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const username = document.getElementById('resetUsername').value;
+      const password = document.getElementById('resetPassword').value;
+      if (await resetPassword(username, password)) {
+        document.getElementById('resetMessage').textContent = 'Password updated. You can log in.';
+      } else {
+        document.getElementById('resetMessage').textContent = 'User not found';
+      }
+    });
+  </script>
+</body>
+</html>

--- a/LK/schema.sql
+++ b/LK/schema.sql
@@ -1,0 +1,6 @@
+CREATE TABLE IF NOT EXISTS users (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  username TEXT UNIQUE NOT NULL,
+  email TEXT,
+  password_hash TEXT NOT NULL
+);

--- a/LK/script.js
+++ b/LK/script.js
@@ -1,0 +1,46 @@
+async function registerUser(username, email, password) {
+  const res = await fetch('/api/register', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ username, email, password })
+  });
+  if (res.ok) {
+    setLoggedInUser(username);
+    return true;
+  }
+  return false;
+}
+
+async function loginUser(username, password) {
+  const res = await fetch('/api/login', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ username, password })
+  });
+  if (res.ok) {
+    setLoggedInUser(username);
+    return true;
+  }
+  return false;
+}
+
+async function resetPassword(username, newPassword) {
+  const res = await fetch('/api/reset-password', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ username, newPassword })
+  });
+  return res.ok;
+}
+
+function setLoggedInUser(username) {
+  localStorage.setItem('loggedInUser', username);
+}
+
+function getLoggedInUser() {
+  return localStorage.getItem('loggedInUser');
+}
+
+function logout() {
+  localStorage.removeItem('loggedInUser');
+}

--- a/LK/server.js
+++ b/LK/server.js
@@ -1,0 +1,69 @@
+const express = require('express');
+const path = require('path');
+const sqlite3 = require('sqlite3').verbose();
+const bcrypt = require('bcryptjs');
+
+const app = express();
+const db = new sqlite3.Database(path.join(__dirname, 'users.db'));
+
+// Initialize table
+const initSql = `CREATE TABLE IF NOT EXISTS users (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  username TEXT UNIQUE NOT NULL,
+  email TEXT,
+  password_hash TEXT NOT NULL
+)`;
+db.run(initSql);
+
+app.use(express.json());
+app.use(express.static(__dirname));
+
+app.post('/api/register', (req, res) => {
+  const { username, email, password } = req.body;
+  if (!username || !password) return res.status(400).json({ error: 'Missing fields' });
+  db.get('SELECT id FROM users WHERE username = ?', [username], async (err, row) => {
+    if (err) return res.status(500).json({ error: 'DB error' });
+    if (row) return res.status(400).json({ error: 'User exists' });
+    try {
+      const hash = await bcrypt.hash(password, 10);
+      db.run('INSERT INTO users(username, email, password_hash) VALUES (?, ?, ?)', [username, email, hash], (err2) => {
+        if (err2) return res.status(500).json({ error: 'DB error' });
+        res.status(201).json({ success: true });
+      });
+    } catch {
+      res.status(500).json({ error: 'Hashing error' });
+    }
+  });
+});
+
+app.post('/api/login', (req, res) => {
+  const { username, password } = req.body;
+  db.get('SELECT password_hash FROM users WHERE username = ?', [username], async (err, row) => {
+    if (err) return res.status(500).json({ error: 'DB error' });
+    if (!row) return res.status(401).json({ error: 'Invalid credentials' });
+    try {
+      const match = await bcrypt.compare(password, row.password_hash);
+      if (!match) return res.status(401).json({ error: 'Invalid credentials' });
+      res.json({ success: true });
+    } catch {
+      res.status(500).json({ error: 'Hashing error' });
+    }
+  });
+});
+
+app.post('/api/reset-password', async (req, res) => {
+  const { username, newPassword } = req.body;
+  try {
+    const hash = await bcrypt.hash(newPassword, 10);
+    db.run('UPDATE users SET password_hash = ? WHERE username = ?', [hash, username], function (err) {
+      if (err) return res.status(500).json({ error: 'DB error' });
+      if (this.changes === 0) return res.status(404).json({ error: 'User not found' });
+      res.json({ success: true });
+    });
+  } catch {
+    res.status(500).json({ error: 'Hashing error' });
+  }
+});
+
+const PORT = process.env.PORT || 3000;
+app.listen(PORT, () => console.log(`Server running on http://localhost:${PORT}`));

--- a/LK/style.css
+++ b/LK/style.css
@@ -1,0 +1,22 @@
+body {
+  font-family: Arial, sans-serif;
+  max-width: 600px;
+  margin: 2rem auto;
+  text-align: center;
+}
+
+button {
+  padding: 0.5rem 1rem;
+  margin: 0.5rem;
+}
+
+form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+input {
+  padding: 0.5rem;
+}

--- a/qwer/README.md
+++ b/qwer/README.md
@@ -1,0 +1,13 @@
+# qwer Demo
+
+Simple static auth demo using localStorage.
+
+## Features
+- Landing page with Login and Register buttons
+- Registration and login forms
+- OAuth sign-in placeholders for Google and Apple
+- Admin panel accessible via `admin:admin` displaying and editing users
+- Personal cabinet for logged-in users
+
+## Usage
+Open `index.html` in a browser. Data is stored in `localStorage`.

--- a/qwer/admin.html
+++ b/qwer/admin.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Admin Panel</title>
+  <link rel="stylesheet" href="style.css">
+  <script src="script.js"></script>
+</head>
+<body>
+  <h1>Admin Panel</h1>
+  <table>
+    <thead>
+      <tr><th>Username</th><th>Password</th><th>Provider</th><th>Actions</th></tr>
+    </thead>
+    <tbody id="userTable"></tbody>
+  </table>
+  <button onclick="logout()">Logout</button>
+  <script>
+    requireAdmin();
+    renderAdminUsers();
+  </script>
+</body>
+</html>

--- a/qwer/cabinet.html
+++ b/qwer/cabinet.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Cabinet</title>
+  <link rel="stylesheet" href="style.css">
+  <script src="script.js"></script>
+</head>
+<body>
+  <h1>Personal Cabinet</h1>
+  <p>Welcome, <span id="user"></span></p>
+  <button onclick="logout()">Logout</button>
+  <script>
+    const u = requireAuth();
+    document.getElementById('user').textContent = u;
+  </script>
+</body>
+</html>

--- a/qwer/index.html
+++ b/qwer/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Landing</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <h1>Welcome</h1>
+  <button onclick="location.href='login.html'">Login</button>
+  <button onclick="location.href='register.html'">Register</button>
+</body>
+</html>

--- a/qwer/login.html
+++ b/qwer/login.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Login</title>
+  <link rel="stylesheet" href="style.css">
+  <script src="script.js"></script>
+  <script src="https://accounts.google.com/gsi/client" async defer></script>
+  <script src="https://appleid.cdn-apple.com/appleauth/static/jsapi/appleid/1/en_US/appleid.auth.js"></script>
+</head>
+<body>
+  <h1>Login</h1>
+  <form id="loginForm">
+    <input id="loginUsername" placeholder="Username" required>
+    <input id="loginPassword" type="password" placeholder="Password" required>
+    <button type="submit">Login</button>
+  </form>
+  <div id="oauthButtons">
+    <div id="g_id_onload" data-client_id="GOOGLE_CLIENT_ID" data-callback="handleGoogleCredential"></div>
+    <div class="g_id_signin" data-type="standard"></div>
+    <div id="appleid-signin" data-color="black" data-border="true" data-type="sign in"></div>
+  </div>
+  <script>
+    document.getElementById('loginForm').addEventListener('submit', function(e){
+      e.preventDefault();
+      if(!login(document.getElementById('loginUsername').value, document.getElementById('loginPassword').value)){
+        alert('Invalid credentials');
+      }
+    });
+    function handleGoogleCredential(res){
+      const data = parseJwt(res.credential);
+      loginWithOAuth(data.email, 'google');
+    }
+    AppleID.auth.init({
+      clientId: 'APPLE_CLIENT_ID',
+      scope: 'name email',
+      redirectURI: location.href,
+      usePopup: true,
+    });
+    document.getElementById('appleid-signin').addEventListener('click', () => {
+      AppleID.auth.signIn().then(res => {
+        const email = res.user?.email || parseJwt(res.authorization.id_token).email;
+        loginWithOAuth(email, 'apple');
+      }).catch(console.error);
+    });
+  </script>
+</body>
+</html>

--- a/qwer/register.html
+++ b/qwer/register.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Register</title>
+  <link rel="stylesheet" href="style.css">
+  <script src="script.js"></script>
+</head>
+<body>
+  <h1>Register</h1>
+  <form id="registerForm">
+    <input id="regUsername" placeholder="Username" required>
+    <input id="regPassword" type="password" placeholder="Password" required>
+    <button type="submit">Register</button>
+  </form>
+  <script>
+    document.getElementById('registerForm').addEventListener('submit', function(e){
+      e.preventDefault();
+      const u = document.getElementById('regUsername').value;
+      const p = document.getElementById('regPassword').value;
+      if(register(u,p)){
+        alert('Registered! Please login.');
+        location.href = 'login.html';
+      } else {
+        alert('User already exists');
+      }
+    });
+  </script>
+</body>
+</html>

--- a/qwer/script.js
+++ b/qwer/script.js
@@ -1,0 +1,98 @@
+function getUsers() {
+  try {
+    return JSON.parse(localStorage.getItem('users')) || [];
+  } catch {
+    return [];
+  }
+}
+function saveUsers(users) {
+  localStorage.setItem('users', JSON.stringify(users));
+}
+function register(username, password) {
+  const users = getUsers();
+  if (users.some(u => u.username === username)) return false;
+  users.push({ username, password });
+  saveUsers(users);
+  return true;
+}
+function login(username, password) {
+  const users = getUsers();
+  const user = users.find(u => u.username === username && u.password === password);
+  if (user) {
+    localStorage.setItem('currentUser', username);
+    if (username === 'admin') {
+      location.href = 'admin.html';
+    } else {
+      location.href = 'cabinet.html';
+    }
+    return true;
+  }
+  return false;
+}
+function loginWithOAuth(email, provider) {
+  const users = getUsers();
+  let user = users.find(u => u.username === email);
+  if (!user) {
+    user = { username: email, password: '', provider };
+    users.push(user);
+    saveUsers(users);
+  }
+  localStorage.setItem('currentUser', email);
+  if (email === 'admin') {
+    location.href = 'admin.html';
+  } else {
+    location.href = 'cabinet.html';
+  }
+}
+function requireAuth() {
+  const u = localStorage.getItem('currentUser');
+  if (!u) {
+    location.href = 'login.html';
+    return null;
+  }
+  return u;
+}
+function requireAdmin() {
+  const u = requireAuth();
+  if (u !== 'admin') {
+    location.href = 'cabinet.html';
+  }
+}
+function logout() {
+  localStorage.removeItem('currentUser');
+  location.href = 'index.html';
+}
+function renderAdminUsers() {
+  const tbody = document.getElementById('userTable');
+  const users = getUsers();
+  tbody.innerHTML = '';
+  users.forEach((u, idx) => {
+    const tr = document.createElement('tr');
+    tr.innerHTML = `
+      <td><input data-idx="${idx}" data-field="username" value="${u.username}"></td>
+      <td><input data-idx="${idx}" data-field="password" value="${u.password}"></td>
+      <td>${u.provider || 'local'}</td>
+      <td><button data-action="save" data-idx="${idx}">Save</button></td>`;
+    tbody.appendChild(tr);
+  });
+  tbody.addEventListener('click', e => {
+    if (e.target.dataset.action === 'save') {
+      const idx = e.target.dataset.idx;
+      const inputs = tbody.querySelectorAll(`input[data-idx="${idx}"]`);
+      const users = getUsers();
+      inputs.forEach(inp => {
+        users[idx][inp.dataset.field] = inp.value;
+      });
+      saveUsers(users);
+      alert('Saved');
+    }
+  });
+}
+function parseJwt(token) {
+  const base64Url = token.split('.')[1];
+  const base64 = base64Url.replace(/-/g, '+').replace(/_/g, '/');
+  const jsonPayload = decodeURIComponent(atob(base64).split('').map(c => {
+    return '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2);
+  }).join(''));
+  return JSON.parse(jsonPayload);
+}

--- a/qwer/style.css
+++ b/qwer/style.css
@@ -1,0 +1,4 @@
+body{font-family:sans-serif;max-width:600px;margin:auto;padding:20px;}
+form{display:flex;flex-direction:column;gap:10px;}
+table{width:100%;border-collapse:collapse;margin-top:20px;}
+th,td{border:1px solid #ccc;padding:5px;}


### PR DESCRIPTION
## Summary
- Introduce `qwer` static auth demo with landing, login, registration, and cabinet pages
- Support admin-only panel to view and edit users stored in `localStorage`
- Add Google and Apple sign-in hooks for alternative authentication methods

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm install` *(fails: ERESOLVE could not resolve)*

------
https://chatgpt.com/codex/tasks/task_e_68a340c93cd8832e894a1825e36e4bba